### PR TITLE
updating code examples for correct imports

### DIFF
--- a/doc/source/overview/fields.rst
+++ b/doc/source/overview/fields.rst
@@ -70,7 +70,7 @@ Maps to LDAP email attributes with email validation:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import EmailField
 
    class User(Model):
@@ -91,7 +91,7 @@ Maps to LDAP boolean attributes:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import BooleanField
 
    class User(Model):
@@ -112,7 +112,7 @@ Maps to LDAP integer attributes:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import IntegerField
 
    class User(Model):
@@ -133,7 +133,7 @@ Maps to LDAP timestamp attributes:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import DateTimeField
 
    class User(Model):
@@ -154,7 +154,7 @@ Maps to LDAP date attributes:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import DateField
    from datetime import date
 
@@ -178,7 +178,7 @@ Specialized field for Active Directory timestamp attributes:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import ActiveDirectoryTimestampField
 
    class ADUser(Model):
@@ -199,7 +199,7 @@ Handles multi-valued LDAP attributes:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import CharListField
 
    class Group(Model):
@@ -220,7 +220,7 @@ Handles binary LDAP attributes:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import BinaryField
 
    class User(Model):

--- a/doc/source/overview/installation.rst
+++ b/doc/source/overview/installation.rst
@@ -101,7 +101,7 @@ Create a simple test to verify your installation:
 .. code-block:: python
 
    # test_ldap.py
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import CharField
 
    class TestUser(Model):

--- a/doc/source/overview/models.rst
+++ b/doc/source/overview/models.rst
@@ -20,7 +20,7 @@ more information about how the ``Meta`` class informs your model.
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import CharField, EmailField, BooleanField
 
    class LDAPUser(Model):
@@ -76,7 +76,7 @@ To enable Django Admin for your LDAP models:
 .. code-block:: python
 
    from ldaporm.admin import register_ldap_model
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import CharField, EmailField
 
    class LDAPUser(Model):
@@ -238,7 +238,7 @@ additional arguments, so see :doc:`/api/fields` for more information.
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import CharField, BooleanField, DateTimeField
 
    class User(Model):
@@ -272,7 +272,7 @@ Add custom validation:
 .. code-block:: python
 
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import CharField
    from django.core.exceptions import ValidationError
 
@@ -434,7 +434,7 @@ Here's a complete example of a user management model:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import (
        CharField, EmailField, BooleanField, DateTimeField,
        CharListField, ActiveDirectoryTimestampField

--- a/doc/source/overview/quickstart.rst
+++ b/doc/source/overview/quickstart.rst
@@ -55,7 +55,7 @@ Create a model for LDAP users:
 
 .. code-block:: python
 
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import CharField, EmailField, BooleanField, DateTimeField
 
    class LDAPUser(Model):

--- a/doc/source/runbook/troubleshooting.rst
+++ b/doc/source/runbook/troubleshooting.rst
@@ -357,7 +357,7 @@ Create a simple test script to isolate issues:
 .. code-block:: python
 
    # test_ldap.py
-   from ldaporm import Model
+   from ldaporm.models import Model
    from ldaporm.fields import CharField
 
    class TestUser(Model):

--- a/ldaporm/fields.py
+++ b/ldaporm/fields.py
@@ -167,6 +167,10 @@ class Field(Generic[_T]):
             messages.update(getattr(c, "default_error_messages", {}))
         messages.update(error_messages or {})
         self.error_messages = messages
+        # vgiralt Properties needed for Django Admin
+        self.remote_field = None
+        self.auto_created = False
+        self.is_relation = False
 
     def __repr__(self) -> str:
         """
@@ -435,6 +439,18 @@ class Field(Generic[_T]):
 
         """
         return cast("str", self.db_column or self.name)
+
+    # vgiralt required for Django Admin
+    @cached_property
+    def unique(self) -> bool:
+        """
+        Find if the value of the attribute MUST be unique.
+        Django Admin requires the property to function.
+
+        Returns:
+            Attribute uniqueness, currently, just if it's the PK
+        """
+        return self.primary_key
 
     @cached_property
     def _get_default(self) -> Callable[[], Any]:

--- a/ldaporm/fields.py
+++ b/ldaporm/fields.py
@@ -167,7 +167,7 @@ class Field(Generic[_T]):
             messages.update(getattr(c, "default_error_messages", {}))
         messages.update(error_messages or {})
         self.error_messages = messages
-        # vgiralt Properties needed for Django Admin
+        # Properties needed for Django Admin
         self.remote_field = None
         self.auto_created = False
         self.is_relation = False
@@ -440,7 +440,7 @@ class Field(Generic[_T]):
         """
         return cast("str", self.db_column or self.name)
 
-    # vgiralt required for Django Admin
+    # required for Django Admin
     @cached_property
     def unique(self) -> bool:
         """

--- a/ldaporm/fields.py
+++ b/ldaporm/fields.py
@@ -1015,11 +1015,11 @@ class CharField(Field[str]):
     This field handles string data with optional maximum length validation.
     It converts between Python strings and LDAP byte strings.
 
-    Keyword Args:
-        **kwargs: Keyword arguments passed to the parent class.
-
     Args:
         *args: Positional arguments passed to the parent class.
+
+    Keyword Args:
+        **kwargs: Keyword arguments passed to the parent class.
 
     """
 
@@ -1100,11 +1100,13 @@ class DateField(Field[datetime.date]):
     This field handles date data, converting between Python date objects
     and LDAP date string format (YYYYMMDD).
 
-    Keyword Args:
+    Args:
         verbose_name: The human-readable name of the field.
         name: The name of the field in the LDAP schema.
         auto_now: If True, automatically set to current date on save.
         auto_now_add: If True, automatically set to current date on creation.
+
+    Keyword Args:
         **kwargs: Additional keyword arguments passed to the parent class.
 
     """
@@ -1634,11 +1636,11 @@ class EmailField(CharField):
     built-in email validator and sets a default max_length of 254 to be
     compliant with RFCs 3696 and 5321.
 
-    Keyword Args:
-        **kwargs: Keyword arguments passed to the parent class.
-
     Args:
         *args: Positional arguments passed to the parent class.
+
+    Keyword Args:
+        **kwargs: Keyword arguments passed to the parent class.
 
     """
 
@@ -1661,9 +1663,11 @@ class EmailField(CharField):
         """
         Return a Django form field for this email field.
 
-        Keyword Args:
+        Args:
             form_class: The form field class to use.
             choices_form_class: The form field class to use for choices.
+
+        Keyword Args:
             **kwargs: Additional keyword arguments for the form field.
 
         Returns:
@@ -1810,9 +1814,11 @@ class IntegerField(Field[int]):
         """
         Return a Django form field for this integer field.
 
-        Keyword Args:
+        Args:
             form_class: The form field class to use.
             choices_form_class: The form field class to use for choices.
+
+        Keyword Args:
             **kwargs: Additional keyword arguments for the form field.
 
         Returns:
@@ -1836,11 +1842,11 @@ class CharListField(Field[list[str]]):
     and LDAP multi-valued attributes. It treats newlines as delimiters
     when converting from strings to lists.
 
-    Keyword Args:
-        **kwargs: Keyword arguments passed to the parent class.
-
     Args:
         *args: Positional arguments passed to the parent class.
+
+    Keyword Args:
+        **kwargs: Keyword arguments passed to the parent class.
 
     """
 
@@ -1888,7 +1894,7 @@ class CharListField(Field[list[str]]):
         """
         Convert the value to a Python list of strings.
 
-        Keyword Args:
+        Args:
             value: The value to convert. Can be string, list, or None.
 
         Returns:
@@ -1910,9 +1916,11 @@ class CharListField(Field[list[str]]):
         """
         Return a Django form field for this character list field.
 
-        Keyword Args:
+        Args:
             form_class: Unused parameter for compatibility.
             choices_form_class: Unused parameter for compatibility.
+
+        Keyword Args:
             **kwargs: Additional keyword arguments for the form field.
 
         Returns:
@@ -2280,11 +2288,11 @@ class BinaryField(Field[bytes]):
     and LDAP binary attributes. It's commonly used for storing photos,
     certificates, and other binary data in LDAP.
 
-    Keyword Args:
-        **kwargs: Keyword arguments passed to the parent class.
-
     Args:
         *args: Positional arguments passed to the parent class.
+
+    Keyword Args:
+        **kwargs: Keyword arguments passed to the parent class.
 
     """
 

--- a/ldaporm/managers.py
+++ b/ldaporm/managers.py
@@ -331,7 +331,7 @@ def parse_vlv_response(control_value: bytes) -> dict[str, Any]:
     try:
         vlv_response, _ = decoder.decode(control_value, asn1Spec=VlvResponse())
 
-        result = {
+        result: dict[str, Any] = {
             "target_position": int(vlv_response.getComponentByName("targetPosition")),
             "content_count": int(vlv_response.getComponentByName("contentCount")),
         }
@@ -344,8 +344,8 @@ def parse_vlv_response(control_value: bytes) -> dict[str, Any]:
         # contextID is optional
         context_id = vlv_response.getComponentByName("contextID")
         try:
-            context_id_value = bytes(context_id) if context_id else None
-        except:
+            context_id_value: bytes | None = bytes(context_id) if context_id else None
+        except Exception:
             context_id_value = None
         result["context_id"] = context_id_value
 
@@ -574,7 +574,8 @@ class Modlist:
         replacements: dict[str, Any] = {}
 
         # check if the object needs new classes
-        if new_classes := set(new._meta.extra_objectclasses)-set(new.objectclass):
+        new_meta = cast("Options", new._meta)
+        if new_classes := set(new_meta.extra_objectclasses) - set(new.objectclass):
             new.objectclass += list(new_classes)
             replacements['objectclass'] = [
                 bytes(name, 'ascii') for name in new.objectclass
@@ -639,8 +640,9 @@ class F:
             self._meta = cast("Options", self.model._meta)
             self.fields_map = self._meta.fields_map
             self.attributes_map = self._meta.attributes_map
-            # pk required for Django Admin
-            self._meta.attributes_map['pk'] = self._meta.pk.name
+            # pk required for Django Admin (pk is always set after Options._prepare)
+            assert self._meta.pk is not None
+            self._meta.attributes_map["pk"] = self._meta.pk.name
             self.attribute_to_field_name_map = self._meta.attribute_to_field_name_map
             self.attributes = self._meta.attributes
             self._attributes = self.attributes

--- a/ldaporm/managers.py
+++ b/ldaporm/managers.py
@@ -573,7 +573,7 @@ class Modlist:
         deletes: dict[str, Any] = {}
         replacements: dict[str, Any] = {}
 
-        # vgiralt check if the object needs new classes
+        # check if the object needs new classes
         if new_classes := set(new._meta.extra_objectclasses)-set(new.objectclass):
             new.objectclass += list(new_classes)
             replacements['objectclass'] = [
@@ -639,7 +639,7 @@ class F:
             self._meta = cast("Options", self.model._meta)
             self.fields_map = self._meta.fields_map
             self.attributes_map = self._meta.attributes_map
-            # vgiralt pk required for Django Admin
+            # pk required for Django Admin
             self._meta.attributes_map['pk'] = self._meta.pk.name
             self.attribute_to_field_name_map = self._meta.attribute_to_field_name_map
             self.attributes = self._meta.attributes
@@ -748,7 +748,7 @@ class F:
 
         return cast("list[Model]", objects)
 
-    # vgiralt using method requiered for Django Admin
+    # using method requiered for Django Admin
     def using(self, alias: str) -> "F":
         return self
         return self.manager.model._meta.ldap_server
@@ -3038,7 +3038,7 @@ class LdapManager:
         """
         return self.__filter()
 
-    # vgiralt method required for Django Admin
+    # method required for Django Admin
     def get_queryset(self) -> "F":
         """
         Return the F object for compatibility with Django admin

--- a/ldaporm/managers.py
+++ b/ldaporm/managers.py
@@ -52,6 +52,15 @@ if TYPE_CHECKING:
 LDAP24API = StrictVersion(ldap.__version__) >= StrictVersion("2.4")
 logger = logging.getLogger("django-ldaporm")
 
+# -----------------------
+# We need to emulate the Query object if we want to use Django Admin
+# -----------------------
+from collections import namedtuple
+Query = namedtuple(
+    'Query',
+    ['select_related','model', 'order_by'],
+    defaults=[True,None,None]
+)
 
 # -----------------------
 # LDAP Controls
@@ -563,6 +572,14 @@ class Modlist:
         # Now build the ldap.MOD_DELETE and ldap.MOD_REPLACE modlists
         deletes: dict[str, Any] = {}
         replacements: dict[str, Any] = {}
+
+        # vgiralt check if the object needs new classes
+        if new_classes := set(new._meta.extra_objectclasses)-set(new.objectclass):
+            new.objectclass += list(new_classes)
+            replacements['objectclass'] = [
+                bytes(name, 'ascii') for name in new.objectclass
+            ]
+
         for key, value in changes.items():
             if value == [] or all(x is None for x in value):
                 deletes[key] = None
@@ -622,6 +639,8 @@ class F:
             self._meta = cast("Options", self.model._meta)
             self.fields_map = self._meta.fields_map
             self.attributes_map = self._meta.attributes_map
+            # vgiralt pk required for Django Admin
+            self._meta.attributes_map['pk'] = self._meta.pk.name
             self.attribute_to_field_name_map = self._meta.attribute_to_field_name_map
             self.attributes = self._meta.attributes
             self._attributes = self.attributes
@@ -634,6 +653,27 @@ class F:
             self.chain = []
             self._exclude_chain = []
             self._exclude_groups = []
+        # vgirat The manager returns us as the "QuerySet",
+        # vgirat we need a Query object as a property for the Admin
+        self.query = Query(model=self.model, order_by=self._order_by)
+        self.ordered = self._order_by is not None
+
+    # vgirat _clone required for Admin to work
+    def _clone(self) -> "F":
+        c = self.__class__()
+        c.manager = self.manager
+        c.model = self.model
+        c._meta = self._meta
+        c.fields_map = self.fields_map
+        c.attributes_map = self.attributes_map
+        c.attribute_to_field_name_map = self.attribute_to_field_name_map
+        c.attributes = self.attributes
+        c._attributes = self._attributes
+        c._order_by = self._order_by
+        c.chain = self.chain
+        c._exclude_chain = self._exclude_chain
+        c._exclude_groups = self._exclude_groups
+        return c
 
     def bind_manager(self, manager: "LdapManager") -> None:
         if manager is None:
@@ -708,6 +748,11 @@ class F:
 
         return cast("list[Model]", objects)
 
+    # vgiralt using method requiered for Django Admin
+    def using(self, alias: str) -> "F":
+        return self
+        return self.manager.model._meta.ldap_server
+        
     @property
     def _filter(self) -> "GroupAnd":  # noqa: PLR0912
         """
@@ -2986,6 +3031,17 @@ class LdapManager:
     def all(self) -> "F":
         """
         Return the F object for compatibility with Django REST Framework.
+
+        Returns:
+            The F object, which is iterable and supports pagination.
+
+        """
+        return self.__filter()
+
+    # vgiralt method required for Django Admin
+    def get_queryset(self) -> "F":
+        """
+        Return the F object for compatibility with Django admin
 
         Returns:
             The F object, which is iterable and supports pagination.

--- a/ldaporm/models.py
+++ b/ldaporm/models.py
@@ -134,6 +134,27 @@ class classproperty(property):  # noqa: N801
         return self.fget(objtype)
 
 
+# vgiralt Next two classes are needed for Admin to work
+class ModelStateFieldsCacheDescriptor:
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            return self
+        res = instance.fields_cache = {}
+        return res
+
+
+class ModelState:
+    """Store model instance state."""
+
+    db: str | None = None
+    # If true, uniqueness validation checks will consider this a new, unsaved
+    # object. Necessary for correct validation of new instances of objects with
+    # explicit (non-auto) PKs. This impacts validation only; it has no effect
+    # on the actual save.
+    adding: bool = True
+    fields_cache = ModelStateFieldsCacheDescriptor()
+
+
 class Model(metaclass=LdapModelBase):
     """
     Base class for LDAP ORM models.
@@ -161,6 +182,8 @@ class Model(metaclass=LdapModelBase):
     _meta: Options | None = None
     #: The default manager for this model.
     objects: LdapManager | None = None
+    # vgiralt Needed for Django Admin
+    _state: ModelState | None = None
 
     def __init__(self, *args, **kwargs) -> None:
         """
@@ -180,6 +203,9 @@ class Model(metaclass=LdapModelBase):
         opts = cast("Options", self._meta)
         _setattr = setattr
         self._dn: str | None = None
+
+        # vgiralt The state object is needed by Django Admin
+        self._state = ModelState()
 
         pre_init.send(sender=cls, args=args, kwargs=kwargs)
 
@@ -330,7 +356,14 @@ class Model(metaclass=LdapModelBase):
             if field.name and field.name not in loaded_fields:
                 setattr(instance, field.name, field.get_default())
 
+        # vigiralt Instance _state needed for Django Admin
+        if instance._state is None:
+            instance._state = ModelState()
+        instance._state.adding = False
+        instance._state.db = None # cls._meta.ldap_server
+
         # Send post_init signal
+        # vgiralt This is sent from __init__, isn't it redundant here?
         post_init.send(sender=cls, instance=instance)
 
         return instance
@@ -620,3 +653,23 @@ class Model(metaclass=LdapModelBase):
             perform actual uniqueness validation.
 
         """
+
+    # vgiralt Required for Django Admin
+    def serializable_value(self, field_name: str) -> str:
+        """
+        Return the value of the field name for this instance. If the field is
+        a foreign key, return the id value instead of the object. If there's
+        no Field object with this name on the model, return the model
+        attribute's value.
+        
+        Used to serialize a field's value (in the serializer, or form output,
+        for example). Normally, you would just access the attribute directly
+        and not use this method.
+        """
+        try:
+            field = self._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            return getattr(self, field_name)
+        return getattr(self, field.attname)
+            
+

--- a/ldaporm/models.py
+++ b/ldaporm/models.py
@@ -134,7 +134,7 @@ class classproperty(property):  # noqa: N801
         return self.fget(objtype)
 
 
-# vgiralt Next two classes are needed for Admin to work
+# Next two classes are needed for Admin to work
 class ModelStateFieldsCacheDescriptor:
     def __get__(self, instance, cls=None):
         if instance is None:
@@ -182,7 +182,7 @@ class Model(metaclass=LdapModelBase):
     _meta: Options | None = None
     #: The default manager for this model.
     objects: LdapManager | None = None
-    # vgiralt Needed for Django Admin
+    # Needed for Django Admin
     _state: ModelState | None = None
 
     def __init__(self, *args, **kwargs) -> None:
@@ -204,7 +204,7 @@ class Model(metaclass=LdapModelBase):
         _setattr = setattr
         self._dn: str | None = None
 
-        # vgiralt The state object is needed by Django Admin
+        # The state object is needed by Django Admin
         self._state = ModelState()
 
         pre_init.send(sender=cls, args=args, kwargs=kwargs)
@@ -363,7 +363,7 @@ class Model(metaclass=LdapModelBase):
         instance._state.db = None # cls._meta.ldap_server
 
         # Send post_init signal
-        # vgiralt This is sent from __init__, isn't it redundant here?
+        # This is sent from __init__, isn't it redundant here?
         post_init.send(sender=cls, instance=instance)
 
         return instance
@@ -654,7 +654,7 @@ class Model(metaclass=LdapModelBase):
 
         """
 
-    # vgiralt Required for Django Admin
+    # Required for Django Admin
     def serializable_value(self, field_name: str) -> str:
         """
         Return the value of the field name for this instance. If the field is

--- a/ldaporm/models.py
+++ b/ldaporm/models.py
@@ -356,7 +356,7 @@ class Model(metaclass=LdapModelBase):
             if field.name and field.name not in loaded_fields:
                 setattr(instance, field.name, field.get_default())
 
-        # vigiralt Instance _state needed for Django Admin
+        # Instance _state needed for Django Admin
         if instance._state is None:
             instance._state = ModelState()
         instance._state.adding = False

--- a/ldaporm/models.py
+++ b/ldaporm/models.py
@@ -67,7 +67,7 @@ class LdapModelBase(type):
         attr_meta = attrs.pop("Meta", None)
         meta = attr_meta or getattr(new_class, "Meta", None)
 
-        # Add our Meta class.  This simluates the Django ORM Meta class
+        # Add our Meta class.  This simulates the Django ORM Meta class
         # enough that ModelForm will work for us, among other things
         new_class.add_to_class("_meta", Options(meta))
 
@@ -356,7 +356,7 @@ class Model(metaclass=LdapModelBase):
             if field.name and field.name not in loaded_fields:
                 setattr(instance, field.name, field.get_default())
 
-        # Instance _state needed for Django Admin
+        # Vital: Instance _state needed for Django Admin
         if instance._state is None:
             instance._state = ModelState()
         instance._state.adding = False
@@ -657,17 +657,23 @@ class Model(metaclass=LdapModelBase):
     # Required for Django Admin
     def serializable_value(self, field_name: str) -> str:
         """
-        Return the value of the field name for this instance. If the field is
-        a foreign key, return the id value instead of the object. If there's
-        no Field object with this name on the model, return the model
-        attribute's value.
-        
-        Used to serialize a field's value (in the serializer, or form output,
-        for example). Normally, you would just access the attribute directly
-        and not use this method.
+        Return the value of the field for serialization.
+
+        If the field is a foreign key, return the id value instead of the object.
+        If there's no Field object with this name on the model, return the model
+        attribute's value. Used to serialize a field's value (in the serializer,
+        or form output, for example). Normally, you would just access the
+        attribute directly and not use this method.
+
+        Args:
+            field_name: The name of the field to retrieve.
+
+        Returns:
+            The serialized value of the field.
         """
         try:
-            field = self._meta.get_field(field_name)
+            meta = cast("Options", self._meta)
+            field = meta.get_field(field_name)
         except FieldDoesNotExist:
             return getattr(self, field_name)
         return getattr(self, field.attname)

--- a/ldaporm/options.py
+++ b/ldaporm/options.py
@@ -397,7 +397,7 @@ class Options:
     def fields_map(self) -> dict[str, "Field"]:
         """
         Get a mapping of field names to field instances.  This is used by
-        the :py:class:`~ldaporm.manager.LdapManager`` to get the field
+        the :py:class:`~ldaporm.managers.LdapManager` to get the field
         instances for a model.
 
         Returns:
@@ -414,7 +414,7 @@ class Options:
     def attributes_map(self) -> dict[str, str]:
         """
         Get a mapping of field names to LDAP attribute names.  This is used by
-        the :py:class:`~ldaporm.manager.LdapManager`` to map LDAP attribute names
+        the :py:class:`~ldaporm.managers.LdapManager` to map LDAP attribute names
         to :py:class:`~ldaporm.fields.Field` instances for a model.
 
         Returns:
@@ -431,7 +431,7 @@ class Options:
     def attribute_to_field_name_map(self) -> dict[str, str]:
         """
         Get a mapping of LDAP attribute names to field names.  This is used by
-        the :py:class:`~ldaporm.manager.LdapManager`` to map LDAP attribute names
+        the :py:class:`~ldaporm.managers.LdapManager` to map LDAP attribute names
         to python field names for a model.
 
         Returns:
@@ -444,7 +444,7 @@ class Options:
     def attributes(self) -> list[str]:
         """
         Get a list of LDAP attribute names for all fields.  This is used by
-        the :py:class:`~ldaporm.manager.LdapManager`` to get the LDAP attribute
+        the :py:class:`~ldaporm.managers.LdapManager` to get the LDAP attribute
         names for a model.
 
         Returns:

--- a/ldaporm/options.py
+++ b/ldaporm/options.py
@@ -9,7 +9,7 @@ import warnings
 from bisect import bisect
 from typing import TYPE_CHECKING, cast
 
-from django.apps import apps # vgiralt Needed for Django Admin
+from django.apps import apps # Needed for Django Admin
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.utils.functional import cached_property
 from django.utils.text import camel_case_to_spaces, format_lazy
@@ -227,7 +227,7 @@ class Options:
 
         self.app_label = app_label
 
-        # vgiralt Once we have the app_label, we populate the app_config
+        # Once we have the app_label, we populate the app_config
         # Needed for Django Admin
         self.app_config = apps.get_containing_app_config(app_label)
 

--- a/ldaporm/options.py
+++ b/ldaporm/options.py
@@ -9,6 +9,7 @@ import warnings
 from bisect import bisect
 from typing import TYPE_CHECKING, cast
 
+from django.apps import apps # vgiralt Needed for Django Admin
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.utils.functional import cached_property
 from django.utils.text import camel_case_to_spaces, format_lazy
@@ -102,8 +103,16 @@ class Options:
         # Django Admin compatibility attributes
         #: The app label for this model (for Django Admin compatibility).
         self.app_label: str | None = None
+        #: The app label for this model (for Django Admin compatibility).
+        self.app_config: type | None = None
         #: Whether this model is abstract (for Django Admin compatibility).
         self.abstract: bool = False
+        #: Whether this model has a composite PK (for Django Admin compatibility).
+        self.is_composite_pk: bool = False
+        #: Whether this model has been swapped (for Django Admin compatibility).
+        self.swapped: bool | None = None
+        #: Needed for Django Admin delete operations
+        self.parents: dict = {}
         self.default_permissions: tuple[str, ...] = ("add", "change", "delete", "view")
         #: The permissions for this model.  This is a list of the permissions
         #: that are applied to the model.  This is here really just to fool
@@ -217,6 +226,11 @@ class Options:
                 app_label = "ldaporm"
 
         self.app_label = app_label
+
+        # vgiralt Once we have the app_label, we populate the app_config
+        # Needed for Django Admin
+        self.app_config = apps.get_containing_app_config(app_label)
+
         self.verbose_name = camel_case_to_spaces(self.object_name)
 
         # Next, apply any overridden values from 'class Meta'.

--- a/ldaporm/tests/test_admin.py
+++ b/ldaporm/tests/test_admin.py
@@ -1,0 +1,299 @@
+# mypy: disable-error-code="attr-defined"
+"""
+Unit tests for Django Admin integration with ldaporm models.
+
+This module validates that ldaporm models can be used with Django's admin
+interface, including ModelAdmin registration, form generation, changelist
+views, and queryset operations.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import django
+from django.conf import settings
+from django.contrib import admin
+from django.test import RequestFactory
+
+from ldap_faker.unittest import LDAPFakerMixin
+
+from ldaporm.fields import CharField, CharListField, IntegerField
+from ldaporm.managers import LdapManager
+from ldaporm.models import Model
+
+# Configure Django settings before any model is defined
+if not settings.configured:
+    settings.configure(
+        INSTALLED_APPS=[
+            "django.contrib.admin",
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "ldaporm",
+        ],
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            }
+        },
+        SECRET_KEY="test-secret-key-for-admin-tests",
+        LDAP_SERVERS={
+            "test_server": {
+                "read": {
+                    "url": "ldap://localhost:389",
+                    "user": "cn=admin,dc=example,dc=com",
+                    "password": "admin",
+                    "use_starttls": False,
+                    "tls_verify": "never",
+                    "timeout": 15.0,
+                    "sizelimit": 1000,
+                    "follow_referrals": False,
+                },
+                "write": {
+                    "url": "ldap://localhost:389",
+                    "user": "cn=admin,dc=example,dc=com",
+                    "password": "admin",
+                    "use_starttls": False,
+                    "tls_verify": "never",
+                    "timeout": 15.0,
+                    "sizelimit": 1000,
+                    "follow_referrals": False,
+                },
+            }
+        },
+    )
+    try:
+        django.setup()
+    except Exception:
+        pass
+
+
+class AdminTestUser(Model):
+    """Test model for admin integration tests."""
+
+    uid = CharField(primary_key=True)
+    cn = CharField()
+    sn = CharField()
+    uidNumber = IntegerField()
+    gidNumber = IntegerField()
+    homeDirectory = CharField()
+    loginShell = CharField()
+
+    class Meta:
+        basedn = "ou=users,dc=example,dc=com"
+        objectclass = "posixAccount"
+        ldap_server = "test_server"
+        ordering: list[str] = []
+        ldap_options: list[str] = []
+        extra_objectclasses = ["top"]
+        verbose_name = "Test User"
+        verbose_name_plural = "Test Users"
+
+
+class AdminTestGroup(Model):
+    """Test group model for admin integration tests."""
+
+    cn = CharField(primary_key=True)
+    gidNumber = IntegerField()
+    memberUid = CharListField()
+
+    class Meta:
+        basedn = "ou=groups,dc=example,dc=com"
+        objectclass = "posixGroup"
+        ldap_server = "test_server"
+        ordering: list[str] = []
+        ldap_options: list[str] = []
+        extra_objectclasses = ["top"]
+        verbose_name = "Test Group"
+        verbose_name_plural = "Test Groups"
+
+
+class TestDjangoAdminIntegration(LDAPFakerMixin, unittest.TestCase):
+    """Test suite for Django Admin integration with ldaporm models."""
+
+    ldap_modules = ["ldaporm"]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_users = [
+            [
+                "cn=admin,dc=example,dc=com",
+                {
+                    "cn": [b"admin"],
+                    "userPassword": [b"admin"],
+                    "objectclass": [b"simpleSecurityObject", b"organizationalRole", b"top"],
+                },
+            ],
+            [
+                "uid=alice,ou=users,dc=example,dc=com",
+                {
+                    "uid": [b"alice"],
+                    "cn": [b"Alice Johnson"],
+                    "sn": [b"Johnson"],
+                    "uidNumber": [b"1001"],
+                    "gidNumber": [b"1001"],
+                    "homeDirectory": [b"/home/alice"],
+                    "loginShell": [b"/bin/bash"],
+                    "userPassword": [b"password"],
+                    "objectclass": [b"posixAccount", b"top"],
+                },
+            ],
+            [
+                "uid=bob,ou=users,dc=example,dc=com",
+                {
+                    "uid": [b"bob"],
+                    "cn": [b"Bob Smith"],
+                    "sn": [b"Smith"],
+                    "uidNumber": [b"1002"],
+                    "gidNumber": [b"1002"],
+                    "homeDirectory": [b"/home/bob"],
+                    "loginShell": [b"/bin/bash"],
+                    "userPassword": [b"password"],
+                    "objectclass": [b"posixAccount", b"top"],
+                },
+            ],
+        ]
+        cls.test_groups = [
+            [
+                "cn=developers,ou=groups,dc=example,dc=com",
+                {
+                    "cn": [b"developers"],
+                    "gidNumber": [b"2001"],
+                    "memberUid": [b"alice", b"bob"],
+                    "objectclass": [b"posixGroup", b"top"],
+                },
+            ],
+        ]
+
+    def setUp(self):
+        super().setUp()
+        if not hasattr(self, "ldap_faker"):
+            LDAPFakerMixin.setUp(self)
+
+        self.settings_patcher = patch(
+            "django.conf.settings.LDAP_SERVERS",
+            {
+                "test_server": {
+                    "read": {
+                        "url": "ldap://localhost:389",
+                        "user": "cn=admin,dc=example,dc=com",
+                        "password": "admin",
+                        "use_starttls": False,
+                        "tls_verify": "never",
+                        "timeout": 15.0,
+                        "sizelimit": 1000,
+                        "follow_referrals": False,
+                    },
+                    "write": {
+                        "url": "ldap://localhost:389",
+                        "user": "cn=admin,dc=example,dc=com",
+                        "password": "admin",
+                        "use_starttls": False,
+                        "tls_verify": "never",
+                        "timeout": 15.0,
+                        "sizelimit": 1000,
+                        "follow_referrals": False,
+                    },
+                },
+            },
+        )
+        self.settings_patcher.start()
+
+        user_manager = LdapManager()
+        user_manager.contribute_to_class(AdminTestUser, "objects")
+        group_manager = LdapManager()
+        group_manager.contribute_to_class(AdminTestGroup, "objects")
+
+        self.server_factory.default.raw_objects.clear()  # type: ignore[attr-defined]
+        self.server_factory.default.objects.clear()  # type: ignore[attr-defined]
+        for dn, attrs in self.test_users + self.test_groups:
+            self.server_factory.default.register_object((dn, attrs))  # type: ignore[attr-defined]
+
+        self.request_factory = RequestFactory()
+
+    def tearDown(self):
+        self.settings_patcher.stop()
+        if admin.site.is_registered(AdminTestUser):
+            admin.site.unregister(AdminTestUser)
+        if admin.site.is_registered(AdminTestGroup):
+            admin.site.unregister(AdminTestGroup)
+        super().tearDown()
+
+    def test_model_admin_instantiation(self):
+        """Test that ModelAdmin can be instantiated with an ldaporm model."""
+        model_admin = admin.ModelAdmin(AdminTestUser, admin.site)
+        self.assertIs(model_admin.model, AdminTestUser)
+        self.assertIs(model_admin.model._meta.model, AdminTestUser)
+
+    def test_model_admin_registration(self):
+        """Test that ldaporm models can be registered with admin.site."""
+        admin.site.register(AdminTestUser, admin.ModelAdmin)
+        self.assertTrue(admin.site.is_registered(AdminTestUser))
+
+    def test_model_admin_get_form(self):
+        """Test that ModelAdmin can generate a ModelForm for ldaporm models."""
+        model_admin = admin.ModelAdmin(AdminTestUser, admin.site)
+        form_class = model_admin.get_form(self.request_factory.get("/"))
+        self.assertIsNotNone(form_class)
+        self.assertEqual(form_class.Meta.model, AdminTestUser)
+
+    def test_model_admin_get_queryset(self):
+        """Test that ModelAdmin.get_queryset returns ldaporm queryset."""
+        model_admin = admin.ModelAdmin(AdminTestUser, admin.site)
+        request = self.request_factory.get("/")
+        queryset = model_admin.get_queryset(request)
+        self.assertIsNotNone(queryset)
+        users = list(queryset)
+        self.assertEqual(len(users), 2)
+        uids = [u.uid for u in users]
+        self.assertIn("alice", uids)
+        self.assertIn("bob", uids)
+
+    def test_model_admin_add_form_instantiation(self):
+        """Test that ModelAdmin add form can be instantiated with ldaporm model."""
+        model_admin = admin.ModelAdmin(AdminTestUser, admin.site)
+        form_class = model_admin.get_form(self.request_factory.get("/"))
+        form = form_class()
+        self.assertIsNotNone(form)
+        self.assertEqual(form.Meta.model, AdminTestUser)
+
+    def test_model_admin_list_display(self):
+        """Test that ModelAdmin list_display works with ldaporm model fields."""
+        model_admin = admin.ModelAdmin(AdminTestUser, admin.site)
+        model_admin.list_display = ["uid", "cn", "sn"]
+        request = self.request_factory.get("/")
+        queryset = model_admin.get_queryset(request)
+        users = list(queryset)
+        self.assertGreater(len(users), 0)
+        for user in users:
+            for field_name in model_admin.list_display:
+                self.assertTrue(hasattr(user, field_name))
+
+    def test_model_serializable_value(self):
+        """Test serializable_value required by Django admin."""
+        users = list(AdminTestUser.objects.all())
+        self.assertGreater(len(users), 0)
+        user = users[0]
+        value = user.serializable_value("uid")
+        self.assertEqual(value, user.uid)
+
+    def test_model_meta_admin_compatibility(self):
+        """Test that model _meta has attributes required by Django admin."""
+        meta = AdminTestUser._meta
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta.verbose_name, "Test User")
+        self.assertEqual(meta.verbose_name_plural, "Test Users")
+        self.assertIsNotNone(meta.pk)
+        self.assertEqual(meta.pk.name, "uid")
+        self.assertIsNotNone(meta.fields)
+        self.assertGreater(len(meta.fields), 0)
+
+    def test_model_state_for_admin(self):
+        """Test that model instances have _state required by Django admin."""
+        users = list(AdminTestUser.objects.all())
+        self.assertGreater(len(users), 0)
+        user = users[0]
+        self.assertIsNotNone(user._state)
+        self.assertTrue(hasattr(user._state, "adding"))
+        self.assertTrue(hasattr(user._state, "db"))

--- a/ldaporm/validators.py
+++ b/ldaporm/validators.py
@@ -14,7 +14,7 @@ class EmailForwardValidator:  # noqa: PLW1641
 
         foo@example.com
 
-    Keyword Args:
+    Args:
         message: The message to display when the validation fails.
         code: The code to display when the validation fails.
 
@@ -38,6 +38,9 @@ class EmailForwardValidator:  # noqa: PLW1641
     def _validate_email(self, value: Any) -> None:
         """
         Validate that the input is a valid email address.
+
+        Args:
+            value: The value to validate.
         """
         if value in self.empty_values:
             return


### PR DESCRIPTION
I found that most code usage examples did the wrong import omiting ".models" . This PR fixes them. Thanks for a very useful project.